### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fin28minutes%2FJavaTutorialForBeginners&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
+
 # Title of the Best Course in the world
 ## Caption for the course.
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

Even if you already have a YouTube channel and this project is already known by many, I think it is still good to add the page views for this repo.

![Screenshot (1667)](https://user-images.githubusercontent.com/47092464/98453639-7ebc1b00-2196-11eb-8d71-d82b91ca79a2.png)
